### PR TITLE
Improve Orderbook Snapshot sample

### DIFF
--- a/samples/JavaScript/orderbook-snapshot/orderbook-snapshot-multi.html
+++ b/samples/JavaScript/orderbook-snapshot/orderbook-snapshot-multi.html
@@ -119,10 +119,10 @@
 			const current = selection.slice(-1)[0];
 
 			const remaining = current ?
-				pairs.filter(p => selected.every(s => !p.startsWith(s))) :
+				pairs.filter(p => selected.every(s => !p.toLowerCase().startsWith(s.toLowerCase()))) :
 				primaries;
 
-			const hints = remaining.filter(r => r.startsWith(current));
+			const hints = remaining.filter(r => r.toLowerCase().startsWith(current.toLowerCase()));
 
 			const prefix = selected.join(',') + (selected.length > 0 ? ',' : '');
 			list.innerHTML = hints.map(suffix =>`<option value="${prefix}${suffix}">`).join('\n');


### PR DESCRIPTION
Make hints case-insensitive
Ignore case when searching for currency pair hints (while user types):
![image](https://github.com/independentreserve/websockets/assets/722409/d8992d30-efa3-4ac6-b0d7-bdf413dda6e5)

Port of independentreserve/ir-exchange#6865